### PR TITLE
Deploy Vercel AI chat worker to Cloudflare

### DIFF
--- a/examples/vercel-ai-chat/ai-binding.ts
+++ b/examples/vercel-ai-chat/ai-binding.ts
@@ -1,4 +1,4 @@
-import { createAgent, createTool, createVectorStore, createDurableChat, createKVStore, createR2Store, createD1Store } from 'vercel/ai-chat';
+import { createAgent, createTool, createVectorStore, createDurableChat, createKVStore, createR2Store, createD1Store, createChatUI } from 'vercel/ai-chat';
 
 export function createAIBinding(env) {
   return createAgent({
@@ -8,6 +8,7 @@ export function createAIBinding(env) {
       createTool('kv', createKVStore(env.KV_STORE)),
       createTool('r2', createR2Store(env.R2_STORE)),
       createTool('d1', createD1Store(env.D1_STORE)),
+      createChatUI()
     ],
   });
 }

--- a/examples/vercel-ai-chat/package.json
+++ b/examples/vercel-ai-chat/package.json
@@ -10,7 +10,8 @@
     "build:worker": "pnpm opennextjs-cloudflare build",
     "preview:worker": "pnpm opennextjs-cloudflare preview",
     "preview": "pnpm build:worker && pnpm preview:worker",
-    "e2e": "playwright test -c e2e/playwright.config.ts"
+    "e2e": "playwright test -c e2e/playwright.config.ts",
+    "deploy:worker": "pnpm run build:worker && pnpm wrangler deploy"
   },
   "dependencies": {
     "react": "^19.0.0",

--- a/examples/vercel-ai-chat/worker.ts
+++ b/examples/vercel-ai-chat/worker.ts
@@ -1,4 +1,4 @@
-import { createAgent, createTool, createVectorStore, createDurableChat, createKVStore, createR2Store, createD1Store } from 'vercel/ai-chat';
+import { createAgent, createTool, createVectorStore, createDurableChat, createKVStore, createR2Store, createD1Store, createChatUI } from 'vercel/ai-chat';
 
 export default {
   async fetch(request, env, ctx) {
@@ -29,6 +29,11 @@ export default {
 
     if (url.pathname === '/api/readme') {
       return new Response(env.README_CONTENT, { status: 200 });
+    }
+
+    if (url.pathname === '/') {
+      const chatUI = createChatUI();
+      return new Response(chatUI, { status: 200, headers: { 'Content-Type': 'text/html' } });
     }
 
     return new Response('Not Found', { status: 404 });

--- a/examples/vercel-ai-chat/wrangler.jsonc
+++ b/examples/vercel-ai-chat/wrangler.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
-  "main": "worker.ts",
+  "main": ".open-next/worker.js",
   "name": "vercel-ai-chat",
   "compatibility_date": "2024-12-30",
   "compatibility_flags": ["nodejs_compat"],


### PR DESCRIPTION
Modify the worker to be deployed immediately from GitHub with the Vercel AI chat UI enabled and available on page landing, and deploy to Cloudflare Workers.

* Add a new script `"deploy:worker": "pnpm run build:worker && pnpm wrangler deploy"` to the `scripts` section in `examples/vercel-ai-chat/package.json`.
* Update `examples/vercel-ai-chat/wrangler.jsonc` to include deployment settings: `"main": ".open-next/worker.js"`, `"name": "vercel-ai-chat"`, `"compatibility_date": "2024-12-30"`, `"compatibility_flags": ["nodejs_compat"]`, and `"assets": { "directory": ".open-next/assets", "binding": "ASSETS" }`.
* Modify `examples/vercel-ai-chat/worker.ts` to import `createChatUI` from `vercel/ai-chat`, add a new route `/` to serve the chat UI, and use `createChatUI` to generate the chat UI and return it in the response.
* Update `examples/vercel-ai-chat/ai-binding.ts` to import `createChatUI` from `vercel/ai-chat` and add `createChatUI` to the tools array in the `createAgent` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/126-colby/opennextjs-cloudflare-vercel-ai/pull/1?shareId=41fa2969-9d47-498d-81ee-2337bb2f1784).