### PR TITLE
Add deploy to Cloudflare workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,1 +1,25 @@
+name: Deploy to Cloudflare
 
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        uses: ./.github/actions/install-dependencies
+
+      - name: Build application
+        run: pnpm run build
+
+      - name: Deploy to Cloudflare
+        run: npx wrangler publish
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
Add deploy to Cloudflare workflow automation in `.github/workflows/main.yml`.

* Add `name` field with value "Deploy to Cloudflare".
* Add `on` field with value `push` and `branches` set to `main`.
* Add `jobs` field with a `deploy` job that runs on `ubuntu-latest`.
* Add steps to the `deploy` job to check out the repository, install dependencies, build the application, and deploy to Cloudflare using `wrangler`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/126-colby/opennextjs-cloudflare-vercel-ai/pull/2?shareId=3c7d55a0-e1f4-4146-b938-7fdbcff956e9).